### PR TITLE
离线文档支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+htmldoc/
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 - Support Flask-RESTX
 - Support flask.views.MethodView
 - Support online debugging
-- Support offline html format document
+- Support offline document
+    - [x] HTML
+    - [ ] Markdown
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Support Flask-RESTX
 - Support flask.views.MethodView
 - Support online debugging
+- Support offline html format document
 
 ## Installation
 
@@ -323,6 +324,8 @@ def delete_data():
 
 ![debugger](flask_docs/assets/debugger.png)
 
+## Offline HTML Document
+Run `flask api_doc html` will generate offline html document at `htmldoc/`
 ## Examples
 
 [Complete example][examples]

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ def delete_data():
 ![debugger](flask_docs/assets/debugger.png)
 
 ## Offline HTML Document
-Run `flask api_doc html` will generate offline html document at `htmldoc/`
+- html : Run `flask docs html` will generate offline html document at `htmldoc/`
 ## Examples
 
 [Complete example][examples]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -326,7 +326,7 @@ def delete_data():
 ![debugger](flask_docs/assets/debugger.png)
 
 # 生成离线文档
-运行 `flask api_doc html` 将在 `htmldoc/` 生成离线文档
+- html ：运行 `flask docs html` 将在 `htmldoc/` 生成离线文档
 ## 示例
 
 [完整示例][examples]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,6 +21,8 @@
 - 支持 flask.views.MethodView
 - 支持在线调试
 - 支持离线文档生成
+    - [x] HTML
+    - [ ] Markdown
 
 ## 安装
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,6 +20,7 @@
 - 支持 Flask-RESTX
 - 支持 flask.views.MethodView
 - 支持在线调试
+- 支持离线文档生成
 
 ## 安装
 
@@ -322,6 +323,8 @@ def delete_data():
 
 ![debugger](flask_docs/assets/debugger.png)
 
+# 生成离线文档
+运行 `flask api_doc html` 将在 `htmldoc/` 生成离线文档
 ## 示例
 
 [完整示例][examples]

--- a/flask_docs/__init__.py
+++ b/flask_docs/__init__.py
@@ -185,7 +185,7 @@ class ApiDoc(object):
                 ) as datafile:
                     html_file.write(html_str)
                     json.dump(data, datafile)
-                shutil.copytree(api_doc.static_folder + "/", "htmldoc/static")
+                shutil.copytree(api_doc.static_folder, "htmldoc/static")
 
             app.register_blueprint(api_doc)
 

--- a/flask_docs/__init__.py
+++ b/flask_docs/__init__.py
@@ -23,6 +23,7 @@ from functools import wraps
 import shutil
 
 from flask import Blueprint, current_app, jsonify, request
+from flask.cli import AppGroup
 
 from flask_docs.version import __version__
 
@@ -157,18 +158,18 @@ class ApiDoc(object):
                     }
                 )
 
-            @api_doc.cli.command("html")
+            docs_cli = AppGroup("docs", short_help="Manage document.")
+            app.cli.add_command(docs_cli)
+            
+            @docs_cli.command("html", short_help="Generate offline html document.")
             def offline_html():
                 html_str = self._render_html()
-                # url_prefix = current_app.config["API_DOC_URL_PREFIX"]
-                # referer = request.headers.get("referer", "http://127.0.0.1")
-                # host = referer.split(url_prefix)[0]
 
                 data_dict = self._get_data_dict()
                 data = {
                     "PROJECT_NAME": PROJECT_NAME,
                     "PROJECT_VERSION": PROJECT_VERSION,
-                    "host": "host",
+                    "host": "http://127.0.0.1",
                     "title": title,
                     "version": version,
                     "description": description,
@@ -189,7 +190,7 @@ class ApiDoc(object):
             app.register_blueprint(api_doc)
 
     def _render_html(self):
-        html_str = ApiDoc.INDEX_HTML.replace("<!-- HTML_MODE -->", "offline")
+        html_str = ApiDoc.INDEX_HTML
         if current_app.config["API_DOC_CDN"]:
             CSS_TEMPLATE = ApiDoc.CSS_TEMPLATE_CDN
             JS_TEMPLATE = ApiDoc.JS_TEMPLATE_CDN

--- a/flask_docs/__init__.py
+++ b/flask_docs/__init__.py
@@ -27,7 +27,7 @@ from flask import Blueprint, current_app, jsonify, request
 from flask.cli import AppGroup
 
 from flask_docs.version import __version__
-
+from flask_docs.exceptions import TargetExistsException
 PROJECT_NAME = "Flask-Docs"
 PROJECT_VERSION = __version__
 
@@ -164,7 +164,8 @@ class ApiDoc(object):
 
             @docs_cli.command("html", short_help="Generate offline html document.")
             @click.option("--out", "-o", help="Out put dir", default="htmldoc", show_default=True)
-            def offline_html(out: str):
+            @click.option("--force", "-f", help="Force override", default=False, show_default=True, is_flag=True)
+            def offline_html(out: str, force: bool):
                 html_str = self._render_html()
 
                 data_dict = self._get_data_dict()
@@ -181,6 +182,8 @@ class ApiDoc(object):
 
                 dest = pathlib.Path(out)
                 if os.path.exists(dest):
+                    if not force:
+                        raise TargetExistsException(out)
                     shutil.rmtree(dest)
                 os.mkdir(dest)
 

--- a/flask_docs/__init__.py
+++ b/flask_docs/__init__.py
@@ -21,7 +21,7 @@ import os
 from collections import OrderedDict
 from functools import wraps
 import shutil
-
+import pathlib
 from flask import Blueprint, current_app, jsonify, request
 from flask.cli import AppGroup
 
@@ -177,15 +177,17 @@ class ApiDoc(object):
                     "data": data_dict,
                 }
 
-                if os.path.exists("./htmldoc"):
-                    shutil.rmtree("./htmldoc")
-                os.mkdir("./htmldoc")
-                with open("./htmldoc/index.html", "w") as html_file, open(
-                    "./htmldoc/data", "w"
+                dest = pathlib.Path("htmldoc")
+                if os.path.exists(dest):
+                    shutil.rmtree(dest)
+                os.mkdir(dest)
+
+                with open(dest / 'index.html', "w") as html_file, open(
+                    dest / 'data', "w"
                 ) as datafile:
                     html_file.write(html_str)
                     json.dump(data, datafile)
-                shutil.copytree(api_doc.static_folder, "htmldoc/static")
+                shutil.copytree(api_doc.static_folder, dest / 'static')
 
             app.register_blueprint(api_doc)
 

--- a/flask_docs/__init__.py
+++ b/flask_docs/__init__.py
@@ -160,7 +160,7 @@ class ApiDoc(object):
 
             docs_cli = AppGroup("docs", short_help="Manage document.")
             app.cli.add_command(docs_cli)
-            
+
             @docs_cli.command("html", short_help="Generate offline html document.")
             def offline_html():
                 html_str = self._render_html()

--- a/flask_docs/__init__.py
+++ b/flask_docs/__init__.py
@@ -22,6 +22,7 @@ from collections import OrderedDict
 from functools import wraps
 import shutil
 import pathlib
+import click
 from flask import Blueprint, current_app, jsonify, request
 from flask.cli import AppGroup
 
@@ -162,7 +163,8 @@ class ApiDoc(object):
             app.cli.add_command(docs_cli)
 
             @docs_cli.command("html", short_help="Generate offline html document.")
-            def offline_html():
+            @click.option("--out", "-o", help="Out put dir", default="htmldoc", show_default=True)
+            def offline_html(out: str):
                 html_str = self._render_html()
 
                 data_dict = self._get_data_dict()
@@ -177,7 +179,7 @@ class ApiDoc(object):
                     "data": data_dict,
                 }
 
-                dest = pathlib.Path("htmldoc")
+                dest = pathlib.Path(out)
                 if os.path.exists(dest):
                     shutil.rmtree(dest)
                 os.mkdir(dest)

--- a/flask_docs/exceptions.py
+++ b/flask_docs/exceptions.py
@@ -1,0 +1,3 @@
+class TargetExistsException(Exception):
+    def __init__(self, dest, *args: object) -> None:
+        super().__init__(f"Target {dest} exists, use -f or --force to override")

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -185,7 +185,7 @@ class CoverageTestCase(unittest.TestCase):
 
     def test_offline_html_doc(self):
         runner = app.test_cli_runner()
-        result = runner.invoke(args=["api_doc", "html"])
+        result = runner.invoke(args=["docs", "html"])
         assert result.exit_code == 0
         assert "index.html" in os.listdir("./htmldoc")
 

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -15,6 +15,7 @@ Author:
 
 
 import sys
+import os
 
 sys.path.append(".")
 
@@ -40,14 +41,12 @@ ApiDoc(app, title="Test App")
 
 class AcceptTestCase(unittest.TestCase):
     def test_accept_docs_api(self):
-
         with app.test_client() as client:
             res = client.get("/docs/api/")
             self.assertEqual(res.status_code, 200)
             self.assertEqual(res.content_type, "text/html; charset=utf-8")
 
     def test_accept_docs_api_data(self):
-
         with app.test_client() as client:
             res = client.get("/docs/api/data")
             self.assertEqual(res.status_code, 200)
@@ -118,7 +117,6 @@ class TodoListExclude(RestfulApiTestRoute):
 
 class CoverageTestCase(unittest.TestCase):
     def test_api_route_coverage(self):
-
         api = Blueprint("api", __name__)
         callback = Blueprint("callback", __name__)
 
@@ -145,7 +143,6 @@ class CoverageTestCase(unittest.TestCase):
             self.assertNotEqual(res.json["data"], {})
 
     def test_restful_api_route_coverage(self):
-
         restful_api = Api(app)
         restful_api.add_resource(TodoList, "/todolist", "/todo")
         restful_api.add_resource(TodoListNone, "/todolist_none")
@@ -161,7 +158,6 @@ class CoverageTestCase(unittest.TestCase):
             self.assertEqual(res.content_type, "application/json")
 
     def test_restx_api_route_coverage(self):
-
         restx_api = RestxApi(app)
         ns = restx_api.namespace("sample", description="Sample RESTX API")
 
@@ -186,6 +182,12 @@ class CoverageTestCase(unittest.TestCase):
             res = client.get("/docs/api/data")
             self.assertEqual(res.status_code, 200)
             self.assertEqual(res.content_type, "application/json")
+
+    def test_offline_html_doc(self):
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["api_doc", "html"])
+        assert result.exit_code == 0
+        assert "index.html" in os.listdir("./htmldoc")
 
 
 if __name__ == "__main__":

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -29,6 +29,7 @@ from flask_restx import Api as RestxApi, Resource as RestxResource
 from flask_restx.reqparse import RequestParser as RestxRequestParser
 
 from flask_docs import ApiDoc
+from flask_docs.exceptions import TargetExistsException
 
 app = Flask(__name__)
 app.config["API_DOC_METHODS_LIST"] = ["GET", "POST", "DELETE"]
@@ -206,6 +207,26 @@ class CoverageTestCase(unittest.TestCase):
         assert "index.html" in os.listdir("htmldoc2")
 
         shutil.rmtree("htmldoc2")
+
+    def test_offline_html_doc_should_error_when_exists(self):
+        runner = app.test_cli_runner()
+        os.mkdir('htmldoc_exists')
+
+        result = runner.invoke(args=["docs", "html", "-o", "htmldoc_exists"])
+
+        assert isinstance(result.exception, TargetExistsException)
+        shutil.rmtree("htmldoc_exists")
+
+    def test_offline_html_doc_should_override_when_use_force(self):
+        runner = app.test_cli_runner()
+        os.mkdir('htmldoc_exists2')
+
+        result = runner.invoke(args=["docs", "html", "-o", "htmldoc_exists2", "--force"])
+
+        assert result.exit_code == 0
+        assert "index.html" in os.listdir("htmldoc_exists2")
+
+        shutil.rmtree("htmldoc_exists2")
 
 
 if __name__ == "__main__":

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -191,6 +191,22 @@ class CoverageTestCase(unittest.TestCase):
 
         shutil.rmtree("htmldoc")
 
+    def test_offline_html_doc_out(self):
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["docs", "html", "--out", "htmldoc2"])
+        assert result.exit_code == 0
+        assert "index.html" in os.listdir("htmldoc2")
+
+        shutil.rmtree("htmldoc2")
+
+    def test_offline_html_doc_out_short_mode(self):
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=["docs", "html", "-o", "htmldoc2"])
+        assert result.exit_code == 0
+        assert "index.html" in os.listdir("htmldoc2")
+
+        shutil.rmtree("htmldoc2")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -20,7 +20,7 @@ import os
 sys.path.append(".")
 
 import unittest
-
+import shutil
 from flask import Blueprint, Flask
 from flask_restful import Api, Resource
 from flask_restful.reqparse import RequestParser
@@ -187,7 +187,9 @@ class CoverageTestCase(unittest.TestCase):
         runner = app.test_cli_runner()
         result = runner.invoke(args=["docs", "html"])
         assert result.exit_code == 0
-        assert "index.html" in os.listdir("./htmldoc")
+        assert "index.html" in os.listdir("htmldoc")
+
+        shutil.rmtree("htmldoc")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
运行 `flask api_doc html` 将在 `htmldoc/` 生成离线文档
由于用到一些公共代码，所以把data和/两个routes中的函数抽取出来作为单独函数了